### PR TITLE
feat(cli): add a print-once option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ Please note that in order to use turbocommit, you will need to set the `OPENAI_A
 ### Generating Conventional Commits with `turbocommit`
 
 <!-- START TABLE HERE -->
-| Short | Long      | Description                              |    Default    |
-| ----- | --------- | ---------------------------------------- | :-----------: |
-| -n    |           | Number of choices to generate            |       1       |
-| -m    | --model   | Model to use                             | gpt-3.5-turbo |
-| -d    | --dry-run | Dry run. Will not ask AI for completions |               |
-| -t    |           | Temperature (t \|0.0 < t < 2.0\|)        |      1.0      |
-| -f    |           | Frequency penalty (f \|-2.0 < f < 2.0\|) |      0.0      |
+| Short | Long         | Description                                 |    Default    |
+| ----- | ------------ | ------------------------------------------- | :-----------: |
+| -n    |              | Number of choices to generate               |       1       |
+| -m    | --model      | Model to use                                | gpt-3.5-turbo |
+| -d    | --dry-run    | Dry run. Will not ask AI for completions    |               |
+| -p    | --print-once | Will not print tokens as they are generated |               |
+| -t    |              | Temperature (t \|0.0 < t < 2.0\|)           |      1.0      |
+| -f    |              | Frequency penalty (f \|-2.0 < f < 2.0\|)    |      0.0      |
 <!-- END TABLE HERE -->
 
 ### Handling Long `git diff`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,7 @@ pub struct Options {
     pub msg: String,
     pub t: f64,
     pub f: f64,
+    pub print_once: bool,
     pub model: openai::Model,
     pub dry_run: bool,
 }
@@ -22,6 +23,7 @@ impl From<&Config> for Options {
             msg: String::new(),
             t: config.default_temperature,
             f: config.default_frequency_penalty,
+            print_once: config.disable_print_as_stream,
             model: config.model,
             dry_run: false,
         }
@@ -80,6 +82,9 @@ impl Options {
                             |f: f64| f.clamp(-2.0, 2.0),
                         );
                     }
+                }
+                "-p" | "--print-once" => {
+                    opts.print_once = true;
                 }
                 "-m" | "--model" => {
                     if let Some(model) = iter.next() {
@@ -148,6 +153,7 @@ fn help() {
     println!("  -n <n>   Number of choices to generate\n",);
     println!("  -m <m>   Model to use\n  --model <m>\n",);
     println!("  -d       Dry run. Will not ask AI for completions\n  --dry-run\n",);
+    println!("  -p       Will not print tokens as they are generated.\n  --print-once \n",);
     println!(
         "  -t <t>   Temperature (|t| 0.0 < t < 2.0)\n{}\n",
         "(https://platform.openai.com/docs/api-reference/chat/create#chat/create-temperature)"
@@ -159,7 +165,7 @@ fn help() {
             .bright_black()
     );
     println!("Anything else will be concatenated into an extra message given to the AI\n");
-    println!("You can change the default for these options and the system message prompt in the config file, that is created the first time running the program\n{}",
+    println!("You can change the defaults for these options and the system message prompt in the config file, that is created the first time running the program\n{}",
         home::home_dir().unwrap_or_else(|| "".into()).join(".turbocommit.yaml").display());
     println!("To go back to the default system message, delete the config file.\n");
     println!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     #[serde(default)]
     pub default_number_of_choices: i32,
     #[serde(default)]
+    pub disable_print_as_stream: bool,
+    #[serde(default)]
     pub system_msg: String,
 }
 
@@ -24,6 +26,7 @@ impl Default for Config {
             default_temperature: 1.0,
             default_frequency_penalty: 0.0,
             default_number_of_choices: 1,
+            disable_print_as_stream: false,
             system_msg: String::from("As an AI that only returns conventional commits, you will receive input from the user in the form of a git diff of all staged files. The user may provide extra information to explain the change. Focus on the why rather than the what and keep it brief. You CANNOT generate anything that is not a conventional commit and a commit message only has 1 head line and at most 1 body.
 Ensure that all commits follow these guidelines
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use colored::Colorize;
 use config::Config;
 use crossterm::{
-    cursor::{self, MoveTo, MoveToColumn, MoveToPreviousLine},
+    cursor::{self, MoveToColumn, MoveToPreviousLine},
     execute,
     style::{Color, Print, ResetColor, SetForegroundColor},
     terminal::{self, Clear, ClearType},
@@ -219,7 +219,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut choices = vec![String::from(""); options.n as usize];
 
     let term_width = terminal::size()?.0 as usize;
-    let term_height = terminal::size()?.1 as usize;
 
     let mut stdout = std::io::stdout();
 
@@ -340,10 +339,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         stdout,
         // MoveTo(0, term_height as u16),
         cursor::RestorePosition,
-        Print(format!(
-            "{}\n",
-            "=======================".bright_black()
-        )),
+        Print(format!("{}\n", "=======================".bright_black())),
     )?;
 
     if choices.len() == 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         process::exit(1);
     };
 
-    let loading_git_animation = tokio::spawn(async {
+    let no_git_anim = options.print_once;
+    let loading_git_animation = tokio::spawn(async move {
+        if no_git_anim {
+            println!("{}", "Extracting Information...".bright_black());
+            return;
+        }
         let emoji_support =
             terminal_supports_emoji::supports_emoji(terminal_supports_emoji::Stream::Stdout);
         let frames = if emoji_support {
@@ -184,7 +189,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .bearer_auth(api_key)
         .body(json);
 
-    let loading_ai_animation = tokio::spawn(async {
+    let no_ai_anim = options.print_once;
+    let loading_ai_animation = tokio::spawn(async move {
+        if no_ai_anim {
+            println!("{}", "Asking AI...".bright_black());
+            return;
+        }
         let emoji_support =
             terminal_supports_emoji::supports_emoji(terminal_supports_emoji::Stream::Stdout);
         let frames = if emoji_support {
@@ -309,14 +319,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if options.print_once {
-        if !loading_ai_animation.is_finished() {
-            loading_ai_animation.abort();
-            execute!(
-                std::io::stdout(),
-                Clear(ClearType::CurrentLine),
-                MoveToColumn(0),
-            )?;
-        }
+        // if !loading_ai_animation.is_finished() {
+        //     loading_ai_animation.abort();
+        //     execute!(
+        //         std::io::stdout(),
+        //         Clear(ClearType::CurrentLine),
+        //         MoveToColumn(0),
+        //     )?;
+        // }
         println!(
             "This used {} tokens costing you about {}\n",
             format!("{}", response_tokens + prompt_tokens).purple(),
@@ -338,7 +348,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     execute!(
         stdout,
         // MoveTo(0, term_height as u16),
-        cursor::RestorePosition,
         Print(format!("{}\n", "=======================".bright_black())),
     )?;
 


### PR DESCRIPTION
This PR adds a new `--print-once` option to the CLI that will disable printing tokens as they are generated.