### PR TITLE
feat(cli): add support for augmenting message

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ pub struct Options {
     pub t: f64,
     pub f: f64,
     pub model: openai::Model,
+    pub augment: String,
     pub dry_run: bool,
 }
 
@@ -23,6 +24,7 @@ impl From<&Config> for Options {
             t: config.default_temperature,
             f: config.default_frequency_penalty,
             model: config.model,
+            augment: String::new(),
             dry_run: false,
         }
     }
@@ -96,6 +98,12 @@ impl Options {
                         };
                     }
                 }
+                "-a" | "--augment" => {
+                    if let Some(augment) = iter.next() {
+                        opts.augment.push_str("\n");
+                        opts.augment.push_str(&augment);
+                    }
+                }
                 "-d" | "--dry-run" => {
                     opts.dry_run = true;
                     println!(
@@ -147,6 +155,7 @@ fn help() {
     println!("Options:");
     println!("  -n <n>   Number of choices to generate\n",);
     println!("  -m <m>   Model to use\n  --model <m>\n",);
+    println!("  -a <a>   Augment Message with string before the body\n  --augment <a>\n",);
     println!("  -d       Dry run. Will not ask AI for completions\n  --dry-run\n",);
     println!(
         "  -t <t>   Temperature (|t| 0.0 < t < 2.0)\n{}\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,6 +253,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 for (i, choice) in choices.iter().enumerate() {
+                    let augmented_choice = augment_message(choice, &options.augment);
                     let outp = format!(
                         "{}{}\n{}\n",
                         if i == 0 {
@@ -270,7 +271,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             "".bright_black()
                         },
                         format!("[{}]====================", format!("{i}").purple()).bright_black(),
-                        choice,
+                        augmented_choice,
                     );
                     print!("{outp}");
                     lines_to_move_up += count_lines(&outp, term_width) - 1;
@@ -405,4 +406,26 @@ pub fn count_lines(text: &str, max_width: usize) -> u16 {
     }
 
     line_count + 1
+}
+
+#[must_use]
+fn augment_message(msg: &str, aug: &str) -> String {
+    let mut ret = String::new();
+
+    if let Some(first_line) = msg.lines().next() {
+        ret.push_str(first_line);
+        ret.push_str("\n");
+    }
+    ret.push_str(aug);
+    ret.push_str("\n");
+
+    for line in msg.lines().skip(1) {
+        if line.is_empty() {
+            continue;
+        }
+        ret.push_str(line);
+        ret.push_str("\n");
+    }
+
+    String::from(ret.trim())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,15 +417,14 @@ fn augment_message(msg: &str, aug: &str) -> String {
         ret.push_str("\n");
     }
     ret.push_str(aug);
-    ret.push_str("\n");
 
     for line in msg.lines().skip(1) {
         if line.is_empty() {
             continue;
         }
-        ret.push_str(line);
         ret.push_str("\n");
+        ret.push_str(line);
     }
 
-    String::from(ret.trim())
+    ret
 }


### PR DESCRIPTION
This change adds the ability to augment commit messages with a custom string before the commit body, which can be useful for providing additional context or information about the commit. The new option can be used with the "-a" or "--augment" flag.

Example:
![Screen recording](https://i.imgur.com/9UE2pox.gif)