### PR TITLE
Stops terminal jump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "turbocommit"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbocommit"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 authors = ["Sett"]
 description = "A CLI tool to create commit messages with gpt-3.5-turbo"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use colored::Colorize;
 use config::Config;
 use crossterm::{
-    cursor::{MoveTo, MoveToColumn, MoveToPreviousLine},
+    cursor::{self, MoveTo, MoveToColumn, MoveToPreviousLine},
     execute,
     style::{Color, Print, ResetColor, SetForegroundColor},
     terminal::{self, Clear, ClearType},
@@ -236,7 +236,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             )?;
             print!("\n\n")
         }
-        execute!(stdout, MoveToPreviousLine(lines_to_move_up),)?;
+
+        execute!(
+            stdout,
+            cursor::SavePosition,
+            MoveToPreviousLine(lines_to_move_up),
+        )?;
         lines_to_move_up = 0;
         match event {
             Ok(Event::Message(message)) => {
@@ -286,8 +291,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     execute!(
         stdout,
-        MoveTo(0, term_height as u16),
-        Print(format!("{}\n", "=======================".bright_black())),
+        // MoveTo(0, term_height as u16),
+        cursor::RestorePosition,
+        Print(format!(
+            "{}\n",
+            "=======================".bright_black()
+        )),
     )?;
 
     if choices.len() == 1 {


### PR DESCRIPTION
The terminal would jump to the bottom to print the commit prompt, after printing the messages.
This fixes that, fix #9 