### PR TITLE
fix(config): do not overwrite existing fields with defaults

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,10 +5,15 @@ use std::process;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
+    #[serde(default)]
     pub model: openai::Model,
+    #[serde(default)]
     pub default_temperature: f64,
+    #[serde(default)]
     pub default_frequency_penalty: f64,
+    #[serde(default)]
     pub default_number_of_choices: i32,
+    #[serde(default)]
     pub system_msg: String,
 }
 


### PR DESCRIPTION
This commit ensures that default values are only applied to missing fields when deserializing the config. This prevents overwriting of existing values with defaults.