### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -19,10 +19,10 @@ jobs:
         TAG=$(git tag --points-at HEAD)
         if [ -z "$TAG" ]; then
           echo "tag_exists=false" >> $GITHUB_ENV
-          echo "::set-output name=tag_exists::false"
+          echo "tag_exists=false" >> $GITHUB_OUTPUT
         else
           echo "tag_exists=true" >> $GITHUB_ENV
-          echo "::set-output name=tag_exists::true"
+          echo "tag_exists=true" >> $GITHUB_OUTPUT
         fi
       shell: bash
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


